### PR TITLE
Fixed sequence schema dump for newer PostgreSQL versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source "http://rubygems.org"
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
 
 # Declare your gem's dependencies in pg_sequencer.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/Guardfile
+++ b/Guardfile
@@ -1,8 +1,0 @@
-# A sample Guardfile
-# More info at https://github.com/guard/guard#readme
-
-guard 'test' do
-  watch(%r{^lib/(.+)\.rb$})     { |m| "test/#{m[1]}_test.rb" }
-  watch(%r{^test/.+_test\.rb$})
-  watch('test/helper.rb')  { "test" }
-end

--- a/README.rdoc
+++ b/README.rdoc
@@ -55,6 +55,9 @@ This is equivalent of the following query:
 
   CREATE SEQUENCE seq_user INCREMENT BY 1 MIN 1 MAX 2000000 START 1 CACHE 10 NO CYCLE
 
+If sequence already exists, creation is skipped.
+If You pass option `drop_if_exists: true`, than existing one is dropped and new is created.
+
 === Reset a sequence's value:
 
   change_sequence "seq_accounts", :restart_with => 50
@@ -68,7 +71,7 @@ This is equivalent to:
   drop_sequence "seq_products"
 
 == Caveats / Bugs
-* Tested with postgres 9.0.4, should work down to 8.1.
+* Tested with postgres 11.7, should work down to 8.4.
 * Listing all the sequences in a database creates n+1 queries (1 to get the names and n to describe each sequence). Is there a way to fully describe all sequences in a database in one query?
 * The "SET SCHEMA" fragment of the ALTER command is not implemented.
 * Oracle/other databases not supported

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2016 Code42, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -35,4 +37,4 @@ Rake::TestTask.new(:test) do |t|
 end
 
 desc 'Default: run unit tests.'
-task :default => :test
+task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -17,17 +17,15 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-require 'rake'
+
 # begin
 #   require 'bundler/setup'
 # rescue LoadError
 #   puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
 # end
 
-desc 'Default: run unit tests.'
-task :default => :test
-
 require 'rake/testtask'
+
 desc 'Test the foreigner plugin.'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
@@ -35,3 +33,6 @@ Rake::TestTask.new(:test) do |t|
   t.pattern = 'test/**/*_test.rb'
   t.verbose = true
 end
+
+desc 'Default: run unit tests.'
+task :default => :test

--- a/lib/pg_sequencer.rb
+++ b/lib/pg_sequencer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2016 Code42, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/lib/pg_sequencer/railtie.rb
+++ b/lib/pg_sequencer/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2016 Code42, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +21,7 @@
 # SOFTWARE.
 module PgSequencer
   class Railtie < Rails::Railtie
-    initializer "pg_sequencer.load_adapter" do
+    initializer 'pg_sequencer.load_adapter' do
       ActiveSupport.on_load :active_record do
         require 'pg_sequencer/connection_adapters/postgresql_adapter'
 
@@ -30,18 +32,9 @@ module PgSequencer
         ActiveRecord::SchemaDumper.class_eval do
           prepend PgSequencer::SchemaDumper
         end
-
       end
 
-  #     if defined?(ActiveRecord::Migration::CommandRecorder)
-  #       ActiveRecord::Migration::CommandRecorder.class_eval do
-  #         include PgSequencer::Migration::CommandRecorder
-  #       end
-  #     end
-  #
-  #     # PgSequencer::Adapter.load!
-  #   end
-
-    end # initializer
+      # end of initializer
+    end
   end
 end

--- a/lib/pg_sequencer/schema_dumper.rb
+++ b/lib/pg_sequencer/schema_dumper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2016 Code42, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -17,19 +19,22 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
+# Used to add `create_sequence(...)` in `db/schema.rb` after creating tables
 module PgSequencer
   module SchemaDumper
     extend ActiveSupport::Concern
 
     def tables(stream)
-      sequences(stream)
       super(stream)
+      sequences(stream) # sequences must go after tables to correctly find sequences created along with them
     end
 
     private
+
     def sequences(stream)
       sequence_statements = @connection.sequences.map do |sequence|
-        statement_parts = [ ('create_sequence ') + sequence.name.inspect ]
+        statement_parts = ['create_sequence ' + sequence.name.inspect]
         statement_parts << (':increment => ' + sequence.options[:increment].inspect)
         statement_parts << (':min => ' + sequence.options[:min].inspect)
         statement_parts << (':max => ' + sequence.options[:max].inspect)

--- a/lib/pg_sequencer/version.rb
+++ b/lib/pg_sequencer/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2016 Code42, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -18,5 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 module PgSequencer
-  VERSION = "0.0.2"
+  VERSION = '0.0.3'
 end

--- a/pg_sequencer.gemspec
+++ b/pg_sequencer.gemspec
@@ -1,27 +1,27 @@
-$:.push File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 # Maintain your gem's version:
-require "pg_sequencer/version"
+require 'pg_sequencer/version'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name        = "pg_sequencer"
+  s.name        = 'pg_sequencer'
   s.version     = PgSequencer::VERSION
-  s.authors     = ["Tony Collen"]
-  s.email       = ["tonyc@code42.com"]
-  s.homepage    = "https://github.com/code42/pg_sequencer/"
-  s.summary     = "Manage postgres sequences in Rails migrations"
-  s.description = "Sequences need some love. pg_sequencer teaches Rails what sequences are, and will dump them to schema.rb, and also lets you create/drop sequences in migrations."
+  s.authors     = ['Tony Collen']
+  s.email       = ['tonyc@code42.com']
+  s.homepage    = 'https://github.com/code42/pg_sequencer/'
+  s.summary     = 'Manage postgres sequences in Rails migrations'
+  s.description = 'Sequences need some love. pg_sequencer teaches Rails what sequences are, and will dump them to schema.rb, and also lets you create/drop sequences in migrations.'
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["Rakefile", "README.rdoc"]
-  s.test_files = Dir["test/**/*"]
+  s.files = Dir['{app,config,db,lib}/**/*'] + ['Rakefile', 'README.rdoc']
+  s.test_files = Dir['test/**/*']
 
   # s.add_dependency "rails", "~> 3.1.0"
   s.add_dependency 'activerecord', '>= 3.0.0'
-  s.add_development_dependency 'activerecord', '>= 3.1.0'
-  s.add_development_dependency "pg", "0.11.0"
-  s.add_development_dependency "guard"
-  s.add_development_dependency "guard-test"
-  s.add_development_dependency "shoulda-context"
-  s.add_development_dependency "rake"
+  s.add_development_dependency 'pg', '0.11.0'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'shoulda-context'
+  s.add_development_dependency 'pry'
 end

--- a/pg_sequencer.gemspec
+++ b/pg_sequencer.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard"
   s.add_development_dependency "guard-test"
   s.add_development_dependency "shoulda-context"
+  s.add_development_dependency "rake"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,10 +19,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-require 'rubygems'
-require 'test/unit'
+
 require 'active_record'
 require 'shoulda-context'
 require 'minitest/autorun'
+require 'pry'
 
 require File.expand_path('../lib/pg_sequencer', __dir__)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2016 Code42, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,4 +23,6 @@ require 'rubygems'
 require 'test/unit'
 require 'active_record'
 require 'shoulda-context'
-require File.expand_path('../../lib/pg_sequencer', __FILE__)
+require 'minitest/autorun'
+
+require File.expand_path('../lib/pg_sequencer', __dir__)

--- a/test/unit/postgresql_adapter_test.rb
+++ b/test/unit/postgresql_adapter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2016 Code42, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -25,133 +27,139 @@ class PostgreSQLAdapterTest < ActiveSupport::TestCase
 
   setup do
     @options = {
-      :increment => 1,
-      :min       => 1,
-      :max       => 2_000_000,
-      :cache     => 5,
-      :cycle     => true
+      increment: 1,
+      min: 1,
+      max: 2_000_000,
+      cache: 5,
+      cycle: true
     }
   end
 
-  context "generating sequence option SQL" do
-    context "for :increment" do
+  context 'generating sequence option SQL' do
+    context 'for :increment' do
       should "include 'INCREMENT BY' in the SQL" do
-        assert_equal(" INCREMENT BY 1", sequence_options_sql(:increment => 1))
-        assert_equal(" INCREMENT BY 2", sequence_options_sql(:increment => 2))
+        assert_equal(' INCREMENT BY 1', sequence_options_sql(increment: 1))
+        assert_equal(' INCREMENT BY 2', sequence_options_sql(increment: 2))
       end
 
-      should "not include the option if nil value specified" do
-        assert_equal("", sequence_options_sql(:increment => nil))
+      should 'not include the option if nil value specified' do
+        assert_equal('', sequence_options_sql(increment: nil))
       end
     end
 
-    context "for :min" do
+    context 'for :min' do
       should "include 'MINVALUE' in the SQL if specified" do
-        assert_equal(" MINVALUE 1", sequence_options_sql(:min => 1))
-        assert_equal(" MINVALUE 2", sequence_options_sql(:min => 2))
+        assert_equal(' MINVALUE 1', sequence_options_sql(min: 1))
+        assert_equal(' MINVALUE 2', sequence_options_sql(min: 2))
       end
 
       should "not include 'MINVALUE' in SQL if set to nil" do
-        assert_equal("", sequence_options_sql(:min => nil))
+        assert_equal('', sequence_options_sql(min: nil))
       end
 
       should "set 'NO MINVALUE' if :min specified as false" do
-        assert_equal(" NO MINVALUE", sequence_options_sql(:min => false))
+        assert_equal(' NO MINVALUE', sequence_options_sql(min: false))
       end
     end
 
-    context "for :max" do
+    context 'for :max' do
       should "include 'MAXVALUE' in the SQL if specified" do
-        assert_equal(" MAXVALUE 1", sequence_options_sql(:max => 1))
-        assert_equal(" MAXVALUE 2", sequence_options_sql(:max => 2))
+        assert_equal(' MAXVALUE 1', sequence_options_sql(max: 1))
+        assert_equal(' MAXVALUE 2', sequence_options_sql(max: 2))
       end
 
       should "not include 'MAXVALUE' in SQL if set to nil" do
-        assert_equal("", sequence_options_sql(:max => nil))
+        assert_equal('', sequence_options_sql(max: nil))
       end
 
       should "set 'NO MAXVALUE' if :min specified as false" do
-        assert_equal(" NO MAXVALUE", sequence_options_sql(:max => false))
+        assert_equal(' NO MAXVALUE', sequence_options_sql(max: false))
       end
     end
 
-    context "for :start" do
+    context 'for :start' do
       should "include 'START WITH' in SQL if specified" do
-        assert_equal(" START WITH 1", sequence_options_sql(:start => 1))
-        assert_equal(" START WITH 2", sequence_options_sql(:start => 2))
-        assert_equal(" START WITH 500", sequence_options_sql(:start => 500))
+        assert_equal(' START WITH 1', sequence_options_sql(start: 1))
+        assert_equal(' START WITH 2', sequence_options_sql(start: 2))
+        assert_equal(' START WITH 500', sequence_options_sql(start: 500))
       end
 
       should "not include 'START WITH' in SQL if specified as nil" do
-        assert_equal("", sequence_options_sql(:start => nil))
+        assert_equal('', sequence_options_sql(start: nil))
       end
     end
 
-    context "for :cache" do
+    context 'for :cache' do
       should "include 'CACHE' in SQL if specified" do
-        assert_equal(" CACHE 1", sequence_options_sql(:cache => 1))
-        assert_equal(" CACHE 2", sequence_options_sql(:cache => 2))
-        assert_equal(" CACHE 500", sequence_options_sql(:cache => 500))
+        assert_equal(' CACHE 1', sequence_options_sql(cache: 1))
+        assert_equal(' CACHE 2', sequence_options_sql(cache: 2))
+        assert_equal(' CACHE 500', sequence_options_sql(cache: 500))
       end
     end
 
-    context "for :cycle" do
+    context 'for :cycle' do
       should "include 'CYCLE' option if specified" do
-        assert_equal(" CYCLE", sequence_options_sql(:cycle => true))
+        assert_equal(' CYCLE', sequence_options_sql(cycle: true))
       end
 
       should "include 'NO CYCLE' option if set as false" do
-        assert_equal(" NO CYCLE", sequence_options_sql(:cycle => false))
+        assert_equal(' NO CYCLE', sequence_options_sql(cycle: false))
       end
 
       should "not include 'CYCLE' statement if specified as nil" do
-        assert_equal("", sequence_options_sql(:cycle => nil))
+        assert_equal('', sequence_options_sql(cycle: nil))
       end
     end
 
-    should "include all options" do
-      assert_equal " INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE", sequence_options_sql(@options.merge(:start => 1))
+    should 'include all options' do
+      assert_equal(' INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE',
+                   sequence_options_sql(@options.merge(start: 1)))
     end
-  end # generating sequence option SQL
 
-  context "creating sequences" do
-    context "without options" do
-      should "generate the proper SQL" do
-        assert_equal("CREATE SEQUENCE things", create_sequence_sql('things'))
-        assert_equal("CREATE SEQUENCE blahs", create_sequence_sql('blahs'))
+    # end of context 'generating sequence option SQL'
+  end
+
+  context 'creating sequences' do
+    context 'without options' do
+      should 'generate the proper SQL' do
+        assert_equal('CREATE SEQUENCE things', create_sequence_sql('things'))
+        assert_equal('CREATE SEQUENCE blahs', create_sequence_sql('blahs'))
       end
     end
 
-    context "with options" do
-      should "include options at the end" do
-        assert_equal("CREATE SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE", create_sequence_sql('things', @options.merge(:start => 1)))
+    context 'with options' do
+      should 'include options at the end' do
+        assert_equal('CREATE SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE',
+                     create_sequence_sql('things', @options.merge(start: 1)))
       end
     end
-  end # creating sequences
+  end
 
-  context "altering sequences" do
-    context "without options" do
-      should "return a blank SQL statement" do
-        assert_equal("", change_sequence_sql('things'))
-        assert_equal("", change_sequence_sql('things', {}))
-        assert_equal("", change_sequence_sql('things', nil))
-      end
-    end
-
-    context "with options" do
-
-      should "include options at the end" do
-        assert_equal("ALTER SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 RESTART WITH 1 CACHE 5 CYCLE", change_sequence_sql('things', @options.merge(:restart => 1)))
+  context 'altering sequences' do
+    context 'without options' do
+      should 'return a blank SQL statement' do
+        assert_equal('', change_sequence_sql('things'))
+        assert_equal('', change_sequence_sql('things', {}))
+        assert_equal('', change_sequence_sql('things', nil))
       end
     end
 
-  end # altering sequences
-
-  context "dropping sequences" do
-    should "generate the proper SQL" do
-      assert_equal("DROP SEQUENCE seq_users", drop_sequence_sql('seq_users'))
-      assert_equal("DROP SEQUENCE seq_items", drop_sequence_sql('seq_items'))
+    context 'with options' do
+      should 'include options at the end' do
+        assert_equal('ALTER SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 RESTART WITH 1 CACHE 5 CYCLE',
+                     change_sequence_sql('things', @options.merge(restart: 1)))
+      end
     end
-  end # dropping sequences
+  end
 
+  context 'dropping sequences' do
+    should 'generate the proper SQL' do
+      assert_equal('DROP SEQUENCE seq_users', drop_sequence_sql('seq_users'))
+      assert_equal('DROP SEQUENCE seq_items', drop_sequence_sql('seq_items'))
+    end
+  end
+
+  context 'getting sequences from DB' do
+    # TODO:  depends on version of PostgreSQL, so we have to mock direct calls to DB
+  end
 end

--- a/test/unit/postgresql_adapter_test.rb
+++ b/test/unit/postgresql_adapter_test.rb
@@ -22,12 +22,31 @@
 require 'helper'
 require 'pg_sequencer/connection_adapters/postgresql_adapter'
 
-class PostgreSQLAdapterTest < ActiveSupport::TestCase
+class TestAdapter
   include PgSequencer::ConnectionAdapters::PostgreSQLAdapter
+  attr_reader :executed_statements, :existing_sequence_names
+  def initialize(existing_sequence_names =[])
+    @existing_sequence_names = existing_sequence_names
+    @executed_statements = []
+  end
 
+  def execute(sql_statement)
+    @executed_statements << sql_statement
+  end
+
+  def select_all(_statement)
+    existing_sequence_names.collect { |name| { 'sequence_name' => name } }
+  end
+end
+
+class PostgreSQLAdapterTest < ActiveSupport::TestCase
+  attr_reader :adapter, :sequence_name, :options
   setup do
+    @adapter = TestAdapter.new
+    @sequence_name = 'test_id_seq'
     @options = {
       increment: 1,
+      start: 4,
       min: 1,
       max: 2_000_000,
       cache: 5,
@@ -36,101 +55,65 @@ class PostgreSQLAdapterTest < ActiveSupport::TestCase
   end
 
   context 'generating sequence option SQL' do
-    context 'for :increment' do
-      should "include 'INCREMENT BY' in the SQL" do
-        assert_equal(' INCREMENT BY 1', sequence_options_sql(increment: 1))
-        assert_equal(' INCREMENT BY 2', sequence_options_sql(increment: 2))
-      end
-
-      should 'not include the option if nil value specified' do
-        assert_equal('', sequence_options_sql(increment: nil))
-      end
+    should "include 'INCREMENT BY' in the SQL if it is specified" do
+      assert_equal(' INCREMENT BY 1', adapter.sequence_options_sql(increment: 1))
+      assert_equal(' INCREMENT BY 2', adapter.sequence_options_sql(increment: 2))
+      assert_equal('', adapter.sequence_options_sql(increment: nil))
     end
 
-    context 'for :min' do
-      should "include 'MINVALUE' in the SQL if specified" do
-        assert_equal(' MINVALUE 1', sequence_options_sql(min: 1))
-        assert_equal(' MINVALUE 2', sequence_options_sql(min: 2))
-      end
-
-      should "not include 'MINVALUE' in SQL if set to nil" do
-        assert_equal('', sequence_options_sql(min: nil))
-      end
-
-      should "set 'NO MINVALUE' if :min specified as false" do
-        assert_equal(' NO MINVALUE', sequence_options_sql(min: false))
-      end
+    should "include 'MINVALUE' in the SQL if specified" do
+      assert_equal(' MINVALUE 1', adapter.sequence_options_sql(min: 1))
+      assert_equal(' MINVALUE 2', adapter.sequence_options_sql(min: 2))
+      assert_equal('', adapter.sequence_options_sql(min: nil))
+      assert_equal(' NO MINVALUE', adapter.sequence_options_sql(min: false))
     end
 
-    context 'for :max' do
-      should "include 'MAXVALUE' in the SQL if specified" do
-        assert_equal(' MAXVALUE 1', sequence_options_sql(max: 1))
-        assert_equal(' MAXVALUE 2', sequence_options_sql(max: 2))
-      end
-
-      should "not include 'MAXVALUE' in SQL if set to nil" do
-        assert_equal('', sequence_options_sql(max: nil))
-      end
-
-      should "set 'NO MAXVALUE' if :min specified as false" do
-        assert_equal(' NO MAXVALUE', sequence_options_sql(max: false))
-      end
+    should "include 'MAXVALUE' in the SQL if specified" do
+      assert_equal(' MAXVALUE 1', adapter.sequence_options_sql(max: 1))
+      assert_equal(' MAXVALUE 2', adapter.sequence_options_sql(max: 2))
+      assert_equal('', adapter.sequence_options_sql(max: nil))
+      assert_equal(' NO MAXVALUE', adapter.sequence_options_sql(max: false))
     end
 
-    context 'for :start' do
-      should "include 'START WITH' in SQL if specified" do
-        assert_equal(' START WITH 1', sequence_options_sql(start: 1))
-        assert_equal(' START WITH 2', sequence_options_sql(start: 2))
-        assert_equal(' START WITH 500', sequence_options_sql(start: 500))
-      end
-
-      should "not include 'START WITH' in SQL if specified as nil" do
-        assert_equal('', sequence_options_sql(start: nil))
-      end
+    should "include 'START WITH' in SQL if specified" do
+      assert_equal(' START WITH 1', adapter.sequence_options_sql(start: 1))
+      assert_equal(' START WITH 2', adapter.sequence_options_sql(start: 2))
+      assert_equal('', adapter.sequence_options_sql(start: nil))
     end
 
-    context 'for :cache' do
-      should "include 'CACHE' in SQL if specified" do
-        assert_equal(' CACHE 1', sequence_options_sql(cache: 1))
-        assert_equal(' CACHE 2', sequence_options_sql(cache: 2))
-        assert_equal(' CACHE 500', sequence_options_sql(cache: 500))
-      end
+    should "include 'CACHE' in SQL if specified" do
+      assert_equal(' CACHE 1', adapter.sequence_options_sql(cache: 1))
+      assert_equal(' CACHE 2', adapter.sequence_options_sql(cache: 2))
+      assert_equal('', adapter.sequence_options_sql(cache: nil))
     end
 
     context 'for :cycle' do
       should "include 'CYCLE' option if specified" do
-        assert_equal(' CYCLE', sequence_options_sql(cycle: true))
-      end
-
-      should "include 'NO CYCLE' option if set as false" do
-        assert_equal(' NO CYCLE', sequence_options_sql(cycle: false))
-      end
-
-      should "not include 'CYCLE' statement if specified as nil" do
-        assert_equal('', sequence_options_sql(cycle: nil))
+        assert_equal(' CYCLE', adapter.sequence_options_sql(cycle: true))
+        assert_equal(' NO CYCLE', adapter.sequence_options_sql(cycle: false))
+        assert_equal('', adapter.sequence_options_sql(cycle: nil))
       end
     end
 
     should 'include all options' do
-      assert_equal(' INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE',
-                   sequence_options_sql(@options.merge(start: 1)))
+      assert_equal(' INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 4 CACHE 5 CYCLE',
+                   adapter.sequence_options_sql(options))
     end
-
     # end of context 'generating sequence option SQL'
   end
 
   context 'creating sequences' do
     context 'without options' do
       should 'generate the proper SQL' do
-        assert_equal('CREATE SEQUENCE things', create_sequence_sql('things'))
-        assert_equal('CREATE SEQUENCE blahs', create_sequence_sql('blahs'))
+        assert_equal('CREATE SEQUENCE things', adapter.create_sequence_sql('things'))
+        assert_equal('CREATE SEQUENCE blahs', adapter.create_sequence_sql('blahs'))
       end
     end
 
     context 'with options' do
       should 'include options at the end' do
-        assert_equal('CREATE SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 1 CACHE 5 CYCLE',
-                     create_sequence_sql('things', @options.merge(start: 1)))
+        assert_equal('CREATE SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 4 CACHE 5 CYCLE',
+                     adapter.create_sequence_sql('things', options))
       end
     end
   end
@@ -138,28 +121,85 @@ class PostgreSQLAdapterTest < ActiveSupport::TestCase
   context 'altering sequences' do
     context 'without options' do
       should 'return a blank SQL statement' do
-        assert_equal('', change_sequence_sql('things'))
-        assert_equal('', change_sequence_sql('things', {}))
-        assert_equal('', change_sequence_sql('things', nil))
+        assert_equal('', adapter.change_sequence_sql('things'))
+        assert_equal('', adapter.change_sequence_sql('things', {}))
+        assert_equal('', adapter.change_sequence_sql('things', nil))
       end
     end
 
     context 'with options' do
       should 'include options at the end' do
         assert_equal('ALTER SEQUENCE things INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 RESTART WITH 1 CACHE 5 CYCLE',
-                     change_sequence_sql('things', @options.merge(restart: 1)))
+                     adapter.change_sequence_sql('things', options.merge(restart: 1)))
       end
     end
   end
 
   context 'dropping sequences' do
     should 'generate the proper SQL' do
-      assert_equal('DROP SEQUENCE seq_users', drop_sequence_sql('seq_users'))
-      assert_equal('DROP SEQUENCE seq_items', drop_sequence_sql('seq_items'))
+      assert_equal('DROP SEQUENCE seq_users', adapter.drop_sequence_sql('seq_users'))
+      assert_equal('DROP SEQUENCE seq_items', adapter.drop_sequence_sql('seq_items'))
     end
   end
 
   context 'getting sequences from DB' do
     # TODO:  depends on version of PostgreSQL, so we have to mock direct calls to DB
+  end
+
+  context 'executing common situations' do
+    should 'create sequence' do
+      assert_equal [], adapter.executed_statements
+
+      adapter.create_sequence(sequence_name, options)
+
+      expected_statements = [
+        "CREATE SEQUENCE #{sequence_name} INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 4 CACHE 5 CYCLE"
+      ]
+      assert_equal expected_statements, adapter.executed_statements
+    end
+
+    should 'alter sequence' do
+      assert_equal [], adapter.executed_statements
+
+      adapter.change_sequence(sequence_name, options)
+
+      expected_statements = [
+        "ALTER SEQUENCE #{sequence_name} INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 CACHE 5 CYCLE"
+      ]
+      assert_equal expected_statements, adapter.executed_statements
+    end
+
+    should 'drop sequence' do
+      assert_equal [], adapter.executed_statements
+
+      adapter.drop_sequence(sequence_name)
+
+      expected_statements = ["DROP SEQUENCE #{sequence_name}"]
+      assert_equal expected_statements, adapter.executed_statements
+    end
+  end
+
+  context 'when sequence with same name already exists' do
+    should 'skip creation by default' do
+      adapter = TestAdapter.new([sequence_name])
+      assert_equal [], adapter.executed_statements
+
+      adapter.create_sequence(sequence_name, options)
+
+      assert_equal [], adapter.executed_statements
+    end
+
+    should 'drop it if :drop_if_exists is set to true' do
+      adapter = TestAdapter.new([sequence_name])
+      assert_equal [], adapter.executed_statements
+
+      adapter.create_sequence(sequence_name, options.merge(drop_if_exists: true))
+
+      expected_statements = [
+        "DROP SEQUENCE #{sequence_name}",
+        "CREATE SEQUENCE #{sequence_name} INCREMENT BY 1 MINVALUE 1 MAXVALUE 2000000 START WITH 4 CACHE 5 CYCLE"
+      ]
+      assert_equal expected_statements, adapter.executed_statements
+    end
   end
 end

--- a/test/unit/schema_dumper_test.rb
+++ b/test/unit/schema_dumper_test.rb
@@ -48,6 +48,8 @@ class SchemaDumperTest < ActiveSupport::TestCase
   end
 
   class MockSchemaDumper
+    prepend PgSequencer::SchemaDumper # modify method `tables` to include sequences
+
     def initialize(connection)
       @connection = connection
     end
@@ -74,8 +76,6 @@ class SchemaDumperTest < ActiveSupport::TestCase
     def trailer(stream)
       stream.puts '# Fake Schema Trailer'
     end
-
-    include PgSequencer::SchemaDumper
   end
 
   context 'dumping the schema' do
@@ -101,10 +101,10 @@ class SchemaDumperTest < ActiveSupport::TestCase
 
       expected_output = <<~SCHEMAEND
         # Fake Schema Header
-        # (No Tables)
           create_sequence "seq_t_item", :increment => 1, :min => 1, :max => 2000000, :start => 1, :cache => 5, :cycle => true
           create_sequence "seq_t_user", :increment => 1, :min => 1, :max => 2000000, :start => 1, :cache => 5, :cycle => true
 
+        # (No Tables)
         # Fake Schema Trailer
       SCHEMAEND
 
@@ -123,10 +123,10 @@ class SchemaDumperTest < ActiveSupport::TestCase
       should 'properly quote false values in schema output' do
         expected_output = <<~SCHEMAEND
           # Fake Schema Header
-          # (No Tables)
             create_sequence "seq_t_item", :increment => 1, :min => false, :max => 2000000, :start => 1, :cache => 5, :cycle => true
             create_sequence "seq_t_user", :increment => 1, :min => false, :max => 2000000, :start => 1, :cache => 5, :cycle => true
 
+          # (No Tables)
           # Fake Schema Trailer
         SCHEMAEND
 

--- a/test/unit/schema_dumper_test.rb
+++ b/test/unit/schema_dumper_test.rb
@@ -22,7 +22,7 @@
 require 'helper'
 
 class SchemaDumperTest < ActiveSupport::TestCase
-  class SequenceDefinition < Struct.new(:name, :options); end
+  SequenceDefinition = Struct.new(:name, :options)
 
   class MockConnection
     attr_accessor :sequences


### PR DESCRIPTION
+ added change in behavior of `create_sequence()` when sequence already exists. By default creation is skipped. If option `:drop_if_exists` equals `true` than old sequence is dropped and new is created.
+ `create_sequence` calls in `schema.rb` are back at end. This is because `create_table()` creates sequences too (for ids), so we can check them.
